### PR TITLE
Link site header to root, make about page the root, move projects to own page

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,12 +12,12 @@
   </head>
   <body>
     <div id="top-of-page"></div>
-    <header id="header">Get Your Own Site</header>
+    <a href="/"><header id="header">Get Your Own Site</header></a>
     <div id="header-subtitle">this one's mine</div>
     <div id="header-sub-subtitle">(aka: the true story of Phil Sofia)</div>
     <nav id="nav">
       <a href="about" class="tag_link">Who Is Phil?</a> |
-      <a href="/" class="tag_link">Projects</a> |
+      <a href="projects" class="tag_link">Projects</a> |
       <a href="contact" class="tag_link">Links &amp; Contact</a>
     </nav>
     <%= yield %>

--- a/app/views/static_pages/projects.html.erb
+++ b/app/views/static_pages/projects.html.erb
@@ -1,0 +1,12 @@
+<span id="section1">
+  <h2>Recent projects:</h2>
+  <p>
+    <a href="https://github.com/nyc-mud-turtles-2015/trainspotter/blob/master/README.md" target="_blank">Trainspotter</a>
+  </p>
+  <p>
+     <a href="https://github.com/jeder28/stack_overphil/blob/master/README.md" target="_blank">Stack OverPhil</a>
+  </p>
+  <p>
+    <a href="https://github.com/philsof/man_up/blob/master/README.md" target="_blank">Man Up (in progress)</a>
+  </p>
+</span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,12 +4,13 @@ Rails.application.routes.draw do
 
   # You can have the root of your site routed with "root"
   # root 'welcome#index'
-  root 'welcome#index'
+  root 'static_pages#about'
 
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'
   get 'contact' => 'static_pages#contact'
   get 'about' => 'static_pages#about'
+  get 'projects' => 'static_pages#projects'
   # Example of named route that can be invoked with purchase_url(id: product.id)
   #   get 'products/:id/purchase' => 'catalog#purchase', as: :purchase
 


### PR DESCRIPTION
So the header now links to root, and so my bio is the root, and so projects has its own page. Site has better UX like this.